### PR TITLE
Add pkgdown reference index and links

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 codecov.yml
 \.github
 README.Rmd
+^_pkgdown\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,3 +44,5 @@ Imports:
 Suggests:
     future,
     testthat
+URL: https://github.com/epiforecasts/ringbp
+BugReports: https://github.com/epiforecasts/ringbp/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,5 +44,5 @@ Imports:
 Suggests:
     future,
     testthat
-URL: https://github.com/epiforecasts/ringbp
+URL: https://epiforecasts.io/ringbp, https://github.com/epiforecasts/ringbp
 BugReports: https://github.com/epiforecasts/ringbp/issues

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,1 +1,24 @@
 url: https://epiforecasts.io/ringbp/
+
+reference:
+  - title: Model
+    contents:
+    - starts_with("outbreak_")
+  - title: Helper functions
+  - subtitle: Probability distribution manipulation
+    contents:
+    - dist_setup
+    - inf_fn
+  - subtitle: Loop wrappers for scenario modelling
+    contents:
+    - parameter_sweep
+    - scenario_sim
+  - title: Post-processing
+    contents:
+    - detect_extinct
+    - extinct_prob
+  - subtitle: Visualisation
+    contents:
+    - rename_variables_for_plotting
+    - box_plot_max_weekly_cases
+

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,1 @@
+url: https://epiforecasts.io/ringbp/


### PR DESCRIPTION
To be able to inspect source code for each function directly from pkgdown website, and to understand better the structure of the package.