### PR TITLE
Return `data.table` with `[]` to avoid silent printing on first call

### DIFF
--- a/R/outbreak_model.R
+++ b/R/outbreak_model.R
@@ -129,5 +129,5 @@ outbreak_model <- function(num.initial.cases = NULL, prop.ascertain = NULL,
                                                           na.rm = TRUE),
                                         cases_per_gen = list(cases_in_gen_vect))]
   # return
-  return(weekly_cases)
+  return(weekly_cases[])
 }

--- a/R/scenario_sim.R
+++ b/R/scenario_sim.R
@@ -74,7 +74,7 @@ scenario_sim <- function(n.sim, prop.ascertain, cap_max_days, cap_cases,
   # bind output together and add simulation index
   res <- data.table::rbindlist(res)
   res[, sim := rep(1:n.sim, rep(floor(cap_max_days / 7) + 1, n.sim)), ]
-  return(res)
+  return(res[])
 }
 
 
@@ -85,6 +85,6 @@ utils::globalVariables(c(".", ".N", ":=", "asym", "control_effectiveness", "cumu
                          "new_cases", "num.initial.cases", "onset", "pext", "prob_extinct", "prop.asym",
                          "r0", "rweibull", "samp", "samples", "scenario", "sim", "sims", "theta", "upper", "value",
                          "week", "weekly_cases", "x", "y", "y0", "y100", "y25", "y50", "y75"))
-                         
+
 
 


### PR DESCRIPTION
This PR addresses #64 by adding `[]` to the `return()` call in `outbreak_model()` and `scenario_sim()` to avoid the issue that `print(<data.table>)` is silent on the first call. 

The reasoning for this idiom is documented in the [{data.table} FAQ](https://cran.r-project.org/web/packages/data.table/vignettes/datatable-faq.html#why-do-i-have-to-type-dt-sometimes-twice-after-using-to-print-the-result-to-console), and needed since [{data.table} v1.9.6](https://github.com/Rdatatable/data.table/blob/master/NEWS.0.md#bug-fixes-1). 

`parameter_sweep()` was already returning a `<data.table>` using the `[]` syntax, and the only other function in the package to return a `<data.table>` is `outbreak_setup()`, but that does not silently return a `<data.table>` (I'm not sure why atm as it does use `:=`) so it does not need returning with `[]`. 