### PR TITLE
Rename `wuhan_sim` to `scenario_sim` in `parameter_sweep` doc

### DIFF
--- a/R/parameter_sweep.R
+++ b/R/parameter_sweep.R
@@ -12,7 +12,7 @@
 #'   simulation function - see the examples for usage.
 #'
 #' @return A nested `data.table` containing the parameters for each scenario and a nested list of output
-#' from `wuhan_sim`.
+#' from [scenario_sim()].
 #' @autoglobal
 #' @export
 #' @importFrom future.apply future_lapply

--- a/man/parameter_sweep.Rd
+++ b/man/parameter_sweep.Rd
@@ -18,7 +18,7 @@ simulation function - see the examples for usage.}
 }
 \value{
 A nested \code{data.table} containing the parameters for each scenario and a nested list of output
-from \code{wuhan_sim}.
+from \code{\link[=scenario_sim]{scenario_sim()}}.
 }
 \description{
 Explore scenarios using gridding with sampling for parameters not in the grid. Parameters that


### PR DESCRIPTION
This PR closes #79 by renaming the `wuhan_sim` mentioned in the function documentation of `parameter_sweep()` with `scenario_sim`. The `wuhan_sim()` function was originally in the {ringbp} package, but was renamed to `scenario_sim()` in 55dfa4aff966994c6cd7a5f272a153fb5e100976. 

Browsing through the version history of the package I did not see any other reference to `wuhan_sim`, so I have no reason to believe it's referencing anything else.