### PR TITLE
Add GHA R CMD check for min R version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,6 +59,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: '3.5'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds an R CMD check run on GitHub actions on the version of R that is stated in the `DESCRIPTION` as the minimum required version. This will ensure the package works currently on users systems that may be running an older version of R. 