### PR TITLE
Install {ggplot2} in `render_readme.yml`

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rmarkdown, any::allcontributors, local::.
+          extra-packages: any::rmarkdown, any::allcontributors, local::., any::ggplot2
 
       - name: Update contributors
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This PR adds the installation of {ggplot2} to the `render_readme.yml` GitHub actions workflow, as this was failing since #84 due to the `README` loading {ggplot2} but it is not a dependency of {ringbp}, thus not installed by default.