### PR TITLE
Add @joshwlambert as ctb

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,11 @@ Type: Package
 Title: Simulate and evaluate contact tracing scenarios
 Version: 0.1.2.9999
 Authors@R: c(
-    person(given = "Joel Hellewell",
+    person("Joel", "Hellewell",
            role = c("aut", "cre"),
            email = "Joel.Hellewell@lshtm.ac.uk",
            comment = c(ORCID = "0000-0003-2683-0849")),
-    person(given = "Sam Abbott",
+    person("Sam", "Abbott",
            role = c("aut"),
            email = "contact@samabbott.co.uk",
            comment = c(ORCID = "0000-0001-8057-8037")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,11 @@ Authors@R: c(
     person("Carl", "Pearson", "A. B.",
            email = "carl.ab.pearson@gmail.com",
            role = c("ctb"),
-           comment = c(ORCID = "0000-0003-0701-7860"))
+           comment = c(ORCID = "0000-0003-0701-7860")),
+    person("Joshua W.", "Lambert",
+           email = "joshua.lambert@lshtm.ac.uk", 
+           role = c("ctb"),
+           comment = c(ORCID = "0000-0001-5218-3046"))
            )
 Description: A package to simulate transmission of an infectious disease and associated efforts to trace conacts and reduce onwards transmission.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Authors@R: c(
            email = "hugo.gruson@data.org",
            role = c("ctb"),
            comment = c(ORCID = "https://orcid.org/0000-0002-4094-1476")),
-    person("Carl", "Pearson", "A. B.",
+    person("Carl A. B.", "Pearson",
            email = "carl.ab.pearson@gmail.com",
            role = c("ctb"),
            comment = c(ORCID = "0000-0003-0701-7860")),

--- a/man/ringbp-package.Rd
+++ b/man/ringbp-package.Rd
@@ -33,6 +33,7 @@ Other contributors:
 \itemize{
   \item Hugo Gruson \email{hugo.gruson@data.org} (\href{https://orcid.org/0000-0002-4094-1476}{ORCID}) [contributor]
   \item Carl A. B. Pearson \email{carl.ab.pearson@gmail.com} (\href{https://orcid.org/0000-0003-0701-7860}{ORCID}) [contributor]
+  \item Joshua W. Lambert \email{joshua.lambert@lshtm.ac.uk} (\href{https://orcid.org/0000-0001-5218-3046}{ORCID}) [contributor]
 }
 
 }


### PR DESCRIPTION
This PR also moves author/contributor initials to the `given` name to remove the deprecation warning from {utils}:

> `It is recommended to use ‘given’ instead of ‘middle’.`

Names are consistently formatted to use `given` and `family`.