### PR TITLE
Miscellaneous minor updates from refactor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ringbp 0.1.2.9999
 
+* The outbreak simulation functions (`scenario_sim()`, `outbreak_model()`, `outbreak_setup()` and `outbreak_step()`) have been refactored to provide a more modular and functional interface. New `delay_opts()`, `event_prob_opts()`, `intervention_opts()`, `offspring_opts()`, and `sim_opts()` helper functions are added. `check_dist_func()` is added and `check_outbreak_input()` removed. The `parameter_sweep()` function is removed and converted into a vignette ({purrr} is removed as a package dependency). `prop_presymptomatic_to_alpha()` is renamed to `presymptomatic_transmission_to_alpha()`. Addresses #65, #91 by @joshwlambert in #127 and reviewed by @pearsonca and @sbfnk.
+
 * The `inf_fn()` function has been renamed to `incubation_to_generation_time()` and the `k` function argument (`scenario_sim()`, `outbreak_model()`, `outbreak_step()`) has been renamed `prop_presymptomatic` (in `scenario_sim()` and `outbreak_model()`) or `alpha` (in `outbreak_step()`). The internal `prop_presymptomatic_to_alpha()` function has been added to do the conversion from `prop_presymptomatic` to `alpha`. Addresses #119, #120 by @joshwlambert in #123 and reviewed by @pearsonca and @sbfnk.
 
 * Added input checking, including new `check_outbreak_input()` function, removed unused argument defaults, consistently ordered arguments in functions, and moved function argument documentation to functions that use the argument. Addresses #89, #91, #93, #116 by @joshwlambert in #117 and reviewed by @pearsonca and @sbfnk.

--- a/README.Rmd
+++ b/README.Rmd
@@ -60,7 +60,7 @@ res <- scenario_sim(
     onset_to_isolation = \(x) stats::rweibull(n = x, shape = 1.651524, scale = 4.287786)
   ),
   event_probs = event_prob_opts(
-    ## no asymptomatic infections
+    ## 10% asymptomatic infections
     asymptomatic = 0.1, 
     ## probability of onward infection time being before symptom onset
     presymptomatic_transmission = 0.5,

--- a/vignettes/parameter-sweep.Rmd
+++ b/vignettes/parameter-sweep.Rmd
@@ -112,7 +112,7 @@ res <- lapply(scenario_sims$data, \(x, n) {
 )
 ```
 
-The output of this parameter sweep is a list of `data.table`s, so to give an idea of what the output looks like we should the first 3 scenarios (there are `r length(res)` in total). See `?scenario_sim` for more information on the contents of these `data.table`s.
+The output of this parameter sweep is a list of `data.table`s, so to give an idea of what the output looks like we show the first 3 scenarios (there are `r length(res)` in total). See `?scenario_sim` for more information on the contents of these `data.table`s.
 
 ```{r}
 head(res, 3)
@@ -155,7 +155,7 @@ head(scenario_sims$sims, 3)
 
 ## Running scenarios in parallel
 
-Finally, we demonstrate how the above example can be easily run in parallel using the [{future} framework](). We load the {future} and {future.apply} R packages for this.
+Finally, we demonstrate how the above example can be easily run in parallel using the [{future} framework](https://www.futureverse.org/). We load the {future} and {future.apply} R packages for this.
 
 ```{r}
 library(future)


### PR DESCRIPTION
This PR makes some minor updates that were missed from PR #127. These include:

- Adding a `NEWS.md` item for the changes in #127.
- Fixing a typo in the `parameter-sweep.Rmd` vignette
- Adding a missing link to the `parameter-sweep.Rmd` vignette
- Updating a comment in the `README` to match the code