### PR TITLE
Use implicit return style

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,0 @@
-linters: linters_with_defaults(
-  return_linter(return_style = "explicit")
-  )
-encoding: "UTF-8"

--- a/R/aux_functions.R
+++ b/R/aux_functions.R
@@ -29,7 +29,7 @@ incubation_to_generation_time <- function(incubation_period_samples, alpha) {
                  omega = 2,
                  alpha = alpha)
 
-  return(pmax(1, out))
+  pmax(1, out)
 }
 
 #' Estimate skew normal alpha parameter from proportion of presymptomatic
@@ -51,7 +51,7 @@ presymptomatic_transmission_to_alpha <- function(presymptomatic_transmission) {
   objective <- function(alpha) {
     # fix x, xi and omega for optimisation
     p_current <- sn::psn(x = 0, xi = 0, omega = 2, alpha = alpha)
-    return((p_current - presymptomatic_transmission)^2)
+    (p_current - presymptomatic_transmission)^2
   }
   # alpha domain is (-Inf, Inf), approximate with large numbers
   res <- stats::optimise(f = objective, interval = c(-1e5, 1e5))
@@ -61,7 +61,7 @@ presymptomatic_transmission_to_alpha <- function(presymptomatic_transmission) {
       "did not converge."
     )
   }
-  return(res$minimum)
+  res$minimum
 }
 
 #' Calculate proportion of runs that have controlled outbreak
@@ -106,7 +106,7 @@ extinct_prob <- function(outbreak_df_week, cap_cases, week_range = 12:16) {
   extinct_runs <- detect_extinct(outbreak_df_week, cap_cases, week_range)
   out <-  sum(extinct_runs$extinct) / n
 
-  return(out)
+  out
 }
 
 
@@ -162,5 +162,5 @@ detect_extinct <- function(outbreak_df_week, cap_cases, week_range = 12:16) {
   out <- outbreak_df_week[, list(
     extinct = fifelse(all(weekly_cases == 0 & cumulative < cap_cases), 1, 0)
   ), by = sim]
-  return(out[])
+  out[]
 }

--- a/R/checking.R
+++ b/R/checking.R
@@ -45,5 +45,5 @@ check_dist_func <- function(func,
     )
   }
 
-  return(TRUE)
+  TRUE
 }

--- a/R/opts.R
+++ b/R/opts.R
@@ -48,7 +48,7 @@ offspring_opts <- function(community, isolated, asymptomatic = community) {
   )
 
   class(opts) <- "ringbp_offspring_opts"
-  return(opts)
+  opts
 }
 
 #' Create a list of delay distributions to run the \pkg{ringbp} model
@@ -81,7 +81,7 @@ delay_opts <- function(incubation_period, onset_to_isolation) {
   )
 
   class(opts) <- "ringbp_delay_opts"
-  return(opts)
+  opts
 }
 
 #' Create a list of event probabilities to run the \pkg{ringbp} model
@@ -123,7 +123,7 @@ event_prob_opts <- function(asymptomatic,
   )
 
   class(opts) <- "ringbp_event_prob_opts"
-  return(opts)
+  opts
 }
 
 #' Create a list of intervention settings to run the \pkg{ringbp} model
@@ -141,7 +141,7 @@ intervention_opts <- function(quarantine = FALSE) {
   checkmate::assert_logical(quarantine, any.missing = FALSE, len = 1)
   opts <- list(quarantine = quarantine)
   class(opts) <- "ringbp_intervention_opts"
-  return(opts)
+  opts
 }
 
 #' Create a list of simulation control options for the \pkg{ringbp} model
@@ -174,5 +174,5 @@ sim_opts <- function(cap_max_days = 350, cap_cases  = 5000) {
   )
 
   class(opts) <- "ringbp_sim_opts"
-  return(opts)
+  opts
 }

--- a/R/outbreak_model.R
+++ b/R/outbreak_model.R
@@ -121,5 +121,5 @@ outbreak_model <- function(initial_cases,
                                                           na.rm = TRUE),
                                         cases_per_gen = list(cases_in_gen_vect))]
   # return
-  return(weekly_cases[])
+  weekly_cases[]
 }

--- a/R/outbreak_setup.R
+++ b/R/outbreak_setup.R
@@ -64,5 +64,5 @@ outbreak_setup <- function(initial_cases, delays, event_probs) {
     isolated_time := onset + delays$onset_to_isolation(.N)
   ]
 
-  return(case_data[])
+  case_data[]
 }

--- a/R/outbreak_step.R
+++ b/R/outbreak_step.R
@@ -180,5 +180,5 @@ outbreak_step <- function(case_data,
   out <- list(case_data, effective_r0, cases_in_gen)
   names(out) <- c("cases", "effective_r0", "cases_in_gen")
 
-  return(out)
+  out
 }

--- a/R/scenario_sim.R
+++ b/R/scenario_sim.R
@@ -81,5 +81,5 @@ scenario_sim <- function(n,
   # bind output together and add simulation index
   res <- data.table::rbindlist(res, idcol = "sim")
 
-  return(res[])
+  res[]
 }


### PR DESCRIPTION
This PR addresses #134 by changing the return style to implicit (i.e. not using `return()`) throughout the package, reserving `return()` for early returns from functions. 

The `.lintr` configuration file was added in #127, with the only non-default linter the `return_style`. Therefore, this file is removed as it is no longer needed now we're moving back to the {lintr} default of implicit returns. 