### PR TITLE
Upgrade to Bootstrap v5 for pkgdown website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ ringbp.Rproj
 inst/doc
 /doc/
 /Meta/
+docs/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,6 @@
 url: https://epiforecasts.io/ringbp/
+template:
+  bootstrap: 5
 
 reference:
   - title: Model


### PR DESCRIPTION
This PR addresses #131 by specifying the Bootstrap version in `_pkgdown.yml` to create the pkgdown website for {ringbp}. 

Bootstrap v5 has been available in [{pkgdown} since v2.0.0](https://pkgdown.r-lib.org/news/index.html?q=bootstrap#pkgdown-200) and Bootstrap v3 was deprecated [since {pkgdown} v2.1.0](https://pkgdown.r-lib.org/news/index.html?q=bootstrap#lifecycle-changes-2-1-0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files to exclude the docs directory from version control.
  * Updated site configuration to use Bootstrap 5 for improved appearance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->