### PR TITLE
Use epiforecasts-workflows app token in render_readme

### DIFF
--- a/.github/workflows/render_readme.yml
+++ b/.github/workflows/render_readme.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Update `render_readme.yml` to use the epiforecasts-workflows GitHub App token
- This allows PRs created by the workflow to trigger CI checks (R-CMD-check, etc.)
- The default `GITHUB_TOKEN` doesn't trigger workflows, but the app token does

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow authentication mechanism for internal processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->