### PR TITLE
Standardise R package naming style

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to ringbp
+# Contributing to `{ringbp}`
 
-This outlines how to propose a change to ringbp. All contributions are welcome.
+This outlines how to propose a change to `{ringbp}`. All contributions are welcome.
 
 ## Fixing typos
 
@@ -61,12 +61,12 @@ Contributions with test cases included are easier to accept.
 
 ### Use cases
 
-We are always interested in hearing about how ringbp is being applied. 
+We are always interested in hearing about how `{ringbp}` is being applied. 
 This helps inform future development priorities by identifying which features are the most used, 
 and which parts of the project lack clarity or need improvement. If you have a use case which 
-you would like to share with us, please do let us know. You can reach out through [email](mailto:joshua.lambert@lshtm.ac.uk). We're grateful for any way that you can spread the word. Whether that's citing the ringbp package in your papers or telling your colleagues about a feature you found useful.
+you would like to share with us, please do let us know. You can reach out through [email](mailto:joshua.lambert@lshtm.ac.uk). We're grateful for any way that you can spread the word. Whether that's citing the `{ringbp}` package in your papers or telling your colleagues about a feature you found useful.
 
 ## Code of Conduct
 
-Please note that the ringbp project is released with a
+Please note that the `{ringbp}` project is released with a
 [Contributor Code of Conduct](https://github.com/epiforecasts/.github/blob/main/CODE_OF_CONDUCT.md). By contributing to this project you agree to abide by its terms.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # ringbp 0.1.2.9999
 
-* The package test suite has been improved, adding several new unit tests, and increasing the test coverage to 100%. The {testthat} edition is incremented to use the 3rd edition. Snapshot (regression) tests are added for `outbreak_setup()` and `scenario_sim()`. Addresses #100 by @joshwlambert in #160 and reviewed by @pearsonca.
+* The package test suite has been improved, adding several new unit tests, and increasing the test coverage to 100%. The `{testthat}` edition is incremented to use the 3rd edition. Snapshot (regression) tests are added for `outbreak_setup()` and `scenario_sim()`. Addresses #100 by @joshwlambert in #160 and reviewed by @pearsonca.
 
 * The lower bound for the generation time returned by `incubation_to_generation_time()` is now greater or equal to the latent period (default 0) instead of 1. A `latent_period` argument has been added to `delay_opts()`. `incubation_to_generation_time()` gains two new arguments: `exposure_time` and `latent_period` to prevent a bug where an infectee's exposure precedes an infector's exposure time. When `latent_period > 0`, generation times are left‑truncated at `latent_period`; this can reduce the realised presymptomatic transmission proportion, for which a warning is issued and the realised value is reported after simulation. Addresses #124 by @joshwlambert in #142 and reviewed by @sbfnk and @pearsonca.
 
-* The outbreak simulation functions (`scenario_sim()`, `outbreak_model()`, `outbreak_setup()` and `outbreak_step()`) have been refactored to provide a more modular and functional interface. New `delay_opts()`, `event_prob_opts()`, `intervention_opts()`, `offspring_opts()`, and `sim_opts()` helper functions are added. `check_dist_func()` is added and `check_outbreak_input()` removed. The `parameter_sweep()` function is removed and converted into a vignette ({purrr} is removed as a package dependency). `prop_presymptomatic_to_alpha()` is renamed to `presymptomatic_transmission_to_alpha()`. Addresses #65, #91 by @joshwlambert in #127 and reviewed by @pearsonca and @sbfnk.
+* The outbreak simulation functions (`scenario_sim()`, `outbreak_model()`, `outbreak_setup()` and `outbreak_step()`) have been refactored to provide a more modular and functional interface. New `delay_opts()`, `event_prob_opts()`, `intervention_opts()`, `offspring_opts()`, and `sim_opts()` helper functions are added. `check_dist_func()` is added and `check_outbreak_input()` removed. The `parameter_sweep()` function is removed and converted into a vignette (`{purrr}` is removed as a package dependency). `prop_presymptomatic_to_alpha()` is renamed to `presymptomatic_transmission_to_alpha()`. Addresses #65, #91 by @joshwlambert in #127 and reviewed by @pearsonca and @sbfnk.
 
 * The `inf_fn()` function has been renamed to `incubation_to_generation_time()` and the `k` function argument (`scenario_sim()`, `outbreak_model()`, `outbreak_step()`) has been renamed `prop_presymptomatic` (in `scenario_sim()` and `outbreak_model()`) or `alpha` (in `outbreak_step()`). The internal `prop_presymptomatic_to_alpha()` function has been added to do the conversion from `prop_presymptomatic` to `alpha`. Addresses #119, #120 by @joshwlambert in #123 and reviewed by @pearsonca and @sbfnk.
 
@@ -16,13 +16,13 @@
 
 * Changed internal sampling to vector draws in several locations; in some cases, this was an optimization, but in others it was a bug fix correcting the use of single draw where there should have been many. Also incorporates other vectorization changes to improve performance. Because of the bug fix, users should expect results to change. Addresses issues #90, #92, #94, in #98 by @pearsonca (now added as a contributor) with review by @sbfnk and @joshwlambert.
 
-* The minimum R version required by the {ringbp} package is now `>= 4.4.0`. This is due to the dependency on {Matrix}. A GitHub actions workflow for R CMD check has been added to check the package is valid on the minimum required R version. Addressed in #85 by @joshwlambert with review by @sbfnk.
+* The minimum R version required by the `{ringbp}` package is now `>= 4.4.0`. This is due to the dependency on `{Matrix}`. A GitHub actions workflow for R CMD check has been added to check the package is valid on the minimum required R version. Addressed in #85 by @joshwlambert with review by @sbfnk.
 
 * Parameterisation of delay distributions accepted by the model have been generalised in `scenario_sim()` and `outbreak_model()`. `delay_shape` and `delay_scale` arguments have been replaced by the `onset_to_isolation` argument, and an `incubation_period` argument is added. Addresses issues #59 and #63 in #84 by @joshwlambert with review by @sbfnk and @pearsonca.
 
 * Function examples are added and updated, and `\dontrun{}` is removed. Addresses issue #27 in #83 by @joshwlambert with review by @pearsonca.
 
-* Use {roxyglobals} to manage global variables. Addresses issue #66 in #81 by @joshwlambert with review by @sbfnk.
+* Use `{roxyglobals}` to manage global variables. Addresses issue #66 in #81 by @joshwlambert with review by @sbfnk.
 
 * Remove silent printing of returned `data.table`s from `outbreak_model()` and `scenario_sim()` by adding `[]` to `return()`. Addresses issue #64 in #80 by @joshwlambert with review from @sbfnk. 
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -12,7 +12,7 @@ knitr::opts_chunk$set(
 set.seed(111)
 ```
 
-# _{{ packagename }}_: Simulate infectious disease transmission with contact tracing
+# `{ringbp}`: Simulate infectious disease transmission with contact tracing
 
 <!-- badges: start -->
 ![GitHub R package version](https://img.shields.io/github/r-package/v/{{ gh_repo }})
@@ -22,20 +22,20 @@ set.seed(111)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <!-- badges: end -->
 
-_{{ packagename }}_ is an R package that provides methods to simulate infectious
+`{ringbp}` is an R package that provides methods to simulate infectious
 disease transmission in the presence of contact tracing. It was
 initially developed to support a paper written in early 2020 to assess
 the feasibility of controlling
 COVID-19; see the [companion analysis code](https://github.com/cmmid/ringbp) and 
 [paper](https://doi.org/10.1016/S2214-109X(20)30074-7) for more details.
 
-_{{ packagename }}_ is an R package that provides methods to simulate infectious disease transmission in the presence of contact tracing.
+`{ringbp}` is an R package that provides methods to simulate infectious disease transmission in the presence of contact tracing.
 It was initially developed to support a paper written in early 2020 to assess the [feasibility of controlling COVID-19](https://github.com/cmmid/ringbp).
 For more details on the methods implemented here, see the associated [paper](https://doi.org/10.1016/S2214-109X(20)30074-7).
 
 ## Installation
 
-The current development version of _{{ packagename }}_ can be installed from [GitHub](https://github.com/) using the `pak` package.
+The current development version of `{ringbp}` can be installed from [GitHub](https://github.com/) using the `pak` package.
 
 ```r
 if(!require("pak")) install.packages("pak")
@@ -104,7 +104,7 @@ extinct_prob(res)
 
 ## Contribute 
 
-Contributions to _{{ packagename }}_ are welcomed. Please follow the [package contributing guide](https://github.com/epiforecasts/ringbp/blob/main/.github/CONTRIBUTING.md).
+Contributions to `{ringbp}` are welcomed. Please follow the [package contributing guide](https://github.com/epiforecasts/ringbp/blob/main/.github/CONTRIBUTING.md).
 
 ## Contributors
 
@@ -152,6 +152,6 @@ All contributions to this project are gratefully acknowledged using the [`allcon
 
 ## Code of Conduct
 
-Please note that the _{{ packagename }}_ project is released with a 
+Please note that the `{ringbp}` project is released with a 
 [Contributor Code of Conduct](https://github.com/epiforecasts/.github/blob/main/CODE_OF_CONDUCT.md).
 By contributing to this project, you agree to abide by its terms.

--- a/vignettes/parameter-sweep.Rmd
+++ b/vignettes/parameter-sweep.Rmd
@@ -14,10 +14,10 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette demonstrates how to run an analysis using the {ringbp} simulation across multiple scenarios.
+This vignette demonstrates how to run an analysis using the `{ringbp}` simulation across multiple scenarios.
 
 ::: {.alert .alert-info}
-The functionality included in this vignette was previously in the `parameter_sweep()` function in {ringbp} <= v0.1.2. This function has been removed as it is preferred to demonstrate the functionality but allow users the flexibility and control to run scenarios in whichever way they choose.
+The functionality included in this vignette was previously in the `parameter_sweep()` function in `{ringbp}` <= v0.1.2. This function has been removed as it is preferred to demonstrate the functionality but allow users the flexibility and control to run scenarios in whichever way they choose.
 :::
 
 ```{r setup}
@@ -25,7 +25,7 @@ library(ringbp)
 library(data.table)
 ```
 
-The `scenario_sim()` function is the core function to run outbreak simulations using {ringbp}, because it allows running the `outbreak_model()` over multiple replicates. 
+The `scenario_sim()` function is the core function to run outbreak simulations using `{ringbp}`, because it allows running the `outbreak_model()` over multiple replicates. 
 
 ## Set up scenario parameter space
 
@@ -155,7 +155,7 @@ head(scenario_sims$sims, 3)
 
 ## Running scenarios in parallel
 
-Finally, we demonstrate how the above example can be easily run in parallel using the [{future} framework](https://www.futureverse.org/). We load the {future} and {future.apply} R packages for this.
+Finally, we demonstrate how the above example can be easily run in parallel using the [`{future}` framework](https://www.futureverse.org/). We load the `{future}` and `{future.apply}` R packages for this.
 
 ```{r}
 library(future)

--- a/vignettes/ringbp-model.Rmd
+++ b/vignettes/ringbp-model.Rmd
@@ -14,17 +14,17 @@ knitr::opts_chunk$set(
 )
 ```
 
-This vignette describes the epidemiological model implemented in the {ringbp} R package. 
+This vignette describes the epidemiological model implemented in the `{ringbp}` R package. 
 
 ## Model Overview
 
-The {ringbp} outbreak model is an individual-level branching process model to simulate an epidemic with individual-level non-pharmaceutical interventions (NPIs), namely: isolation, contact tracing and quarantine. 
+The `{ringbp}` outbreak model is an individual-level branching process model to simulate an epidemic with individual-level non-pharmaceutical interventions (NPIs), namely: isolation, contact tracing and quarantine. 
 
 ***Isolation***: Any infected individual that becomes symptomatic gets tested, and is isolated after a symptom onset-to-isolation delay.
 
-***Contact tracing***: If contact tracing is in operation the infectee can also be isolated as soon as they develop symptoms if the infector is isolating. Contact tracing in the {ringbp} model is a user-controlled parameter. Users can adjust the proportion of contacts ascertained by tracing between 0% (i.e. nobody is contact traced) and 100% (i.e. every symptomatic infector has all their contacts traced).
+***Contact tracing***: If contact tracing is in operation the infectee can also be isolated as soon as they develop symptoms if the infector is isolating. Contact tracing in the `{ringbp}` model is a user-controlled parameter. Users can adjust the proportion of contacts ascertained by tracing between 0% (i.e. nobody is contact traced) and 100% (i.e. every symptomatic infector has all their contacts traced).
 
-***Quarantine***: Users can turn on quarantine in the model. If quarantine is activated in the model then an infectee can be quarantined/isolated as soon as their infector goes into isolation, independent of whether they are symptomatic. Quarantine can be turned on or off in the {ringbp} model and affects the whole population.
+***Quarantine***: Users can turn on quarantine in the model. If quarantine is activated in the model then an infectee can be quarantined/isolated as soon as their infector goes into isolation, independent of whether they are symptomatic. Quarantine can be turned on or off in the `{ringbp}` model and affects the whole population.
 
 In the scenarios that contacts are being traced in the model (i.e. the proportion of contacts ascertained > 0%), or quarantine is active, then the infectee is isolated at either the infector's isolation time or an onset-to-isolation delay after their symptom onset time, whichever happens earlier. This means that in scenarios where contact tracing and quarantine are active it is possible that infectees are isolated before their infector. The infectee's outcome cannot influence infector's isolation, unlike infector's isolation affecting infectees.
 
@@ -57,7 +57,7 @@ The schematic also shows a scenario in which isolation completely prevents disea
 
 ## Presymptomatic transmission scenarios with interventions
 
-All of the scenarios in the figure above assume that transmission occurs after the infector is symptomatic. The {ringbp} model can also model presymptomatic transmission. Below is another figure enumerating scenarios, but this time assuming that the infector infects the infectee before becoming symptomatic.
+All of the scenarios in the figure above assume that transmission occurs after the infector is symptomatic. The `{ringbp}` model can also model presymptomatic transmission. Below is another figure enumerating scenarios, but this time assuming that the infector infects the infectee before becoming symptomatic.
 
 ![ringbp model schematic scenarios where transmission occurs before symptom onset.](../man/figures/model_schematic_scenario_presym.svg){width=800px}\
 
@@ -73,7 +73,7 @@ Scenario (7b) corresponds to scenario (7) where the infectee is isolated before 
 
 ## Transmission in isolation
 
-So far we have assumed that once cases are isolated they cannot transmit. However, the {ringbp} epidemic model allows the user to specify any offspring distribution for isolated individuals. 
+So far we have assumed that once cases are isolated they cannot transmit. However, the `{ringbp}` epidemic model allows the user to specify any offspring distribution for isolated individuals. 
 
 Infectees that are infected by someone isolating are not isolated until an onset-to-isolation delay after they become symptomatic.
 
@@ -87,9 +87,9 @@ Below we show the same 3-person outbreak schematic as above, but this time isola
 
 ## Model parameters
 
-The table below includes the {ringbp} parameters mentioned in this vignette that users can specify. Parameter values are given as examples and do not represent the default values.
+The table below includes the `{ringbp}` parameters mentioned in this vignette that users can specify. Parameter values are given as examples and do not represent the default values.
 
-| Epidemiological Parameter | {ringbp} Model Parameterisation |
+| Epidemiological Parameter | `{ringbp}` Model Parameterisation |
 | --- | ----------- |
 | Incubation period distribution | `delay_opts(incubation_period = \(n) rgamma(n = n, shape = 2, scale = 2))` |
 | Onset-to-isolation delay distribution | `delay_opts(onset_to_isolation = \(n) rgamma(n = n, shape = 2, scale = 2))` |
@@ -98,7 +98,7 @@ The table below includes the {ringbp} parameters mentioned in this vignette that
 | Contact tracing case ascertainment | `event_prob_opts(symptomatic_traced = 0.5)` |
 | Quarantine | `intervention_opts(quarantine = TRUE)` |
 
-In the {ringbp} model the generation time is not parameterised, instead it is the result of the incubation period distribution and the proportion of transmission that occurs presymptomatically. The minimum generation time can be set by specifying a `latent_period` in the `delay_opts()` function, however, a non-zero latent period may alter the proportion of presymptomatic transmission from what was set by the user.
+In the `{ringbp}` model the generation time is not parameterised, instead it is the result of the incubation period distribution and the proportion of transmission that occurs presymptomatically. The minimum generation time can be set by specifying a `latent_period` in the `delay_opts()` function, however, a non-zero latent period may alter the proportion of presymptomatic transmission from what was set by the user.
 
 Defined mathematically, for individual $i = 1, \dots, n$, let
 \begin{align}
@@ -148,7 +148,7 @@ E_j = G_i + E_i
 
 For the purposes of illustration, the scenarios presented in this vignette include the fewest transmission events possible. The transmissibility of symptomatic or asymptomatic cases in the community, or cases in isolation in the simulation model can be set by specifying the offspring distribution using the `offspring_opts()` function.
 
-The `scenario_sim()` function runs the {ringbp} model for a specified number of replicates.
+The `scenario_sim()` function runs the `{ringbp}` model for a specified number of replicates.
 
 ## Further information
 

--- a/vignettes/ringbp.Rmd
+++ b/vignettes/ringbp.Rmd
@@ -20,18 +20,18 @@ knitr::opts_chunk$set(
 
 ## Introduction
 
-Understanding how an infectious disease might spread, and under what conditions it can be controlled, is crucial for public health planning. The {ringbp} R package provides tools for simulating infectious disease transmission using a branching process model with explicit representation of case detection, isolation, and contact tracing. The package was developed in the early phase of the COVID-19 pandemic to support epidemiological analyses of outbreak dynamics and control feasibility.
+Understanding how an infectious disease might spread, and under what conditions it can be controlled, is crucial for public health planning. The `{ringbp}` R package provides tools for simulating infectious disease transmission using a branching process model with explicit representation of case detection, isolation, and contact tracing. The package was developed in the early phase of the COVID-19 pandemic to support epidemiological analyses of outbreak dynamics and control feasibility.
 
 This vignette provides a brief introduction to the package and demonstrates how to:
 
-* load ringbp
+* load `{ringbp}`
 * specify epidemiological parameters
 * run outbreak simulations
 * plot and summarise simulation results
 
 It concludes with a simplified version of the analysis of COVID-19 control feasibility from @Hellewell2020.
 
-Firstly, we load the {ringbp} package, as well as the {data.table} and {tinyplot} packages which are used in this vignette.
+Firstly, we load the `{ringbp}` package, as well as the `{data.table}` and `{tinyplot}` packages which are used in this vignette.
 
 ```{r setup}
 library(ringbp)
@@ -41,7 +41,7 @@ library(tinyplot)
 
 ## Model overview
 
-At its core, {ringbp} simulates outbreaks using a branching process model. Each infected individual generates secondary infections according to an offspring distribution, with modifications arising from:
+At its core, `{ringbp}` simulates outbreaks using a branching process model. Each infected individual generates secondary infections according to an offspring distribution, with modifications arising from:
 
 * delays between infection, symptom onset, and isolation
 * probabilities governing asymptomatic infection and case detection
@@ -49,7 +49,7 @@ At its core, {ringbp} simulates outbreaks using a branching process model. Each 
 
 Simulations are constructed by combining a set of options that describe these components and then running one or more stochastic outbreak realisations.
 
-For a more detailed exposition of the {ringbp} epidemiological model and how non-pharmaceutical interventions influence disease transmission see the [`ringbp-model.Rmd` vignette](ringbp-model.html).
+For a more detailed exposition of the `{ringbp}` epidemiological model and how non-pharmaceutical interventions influence disease transmission see the [`ringbp-model.Rmd` vignette](ringbp-model.html).
 
 ## Specifying model components
 
@@ -90,7 +90,7 @@ delays <- delay_opts(
 
 _Isolation_ is the separation of infectious individuals from others, with the aim to prevent further transmission.
 
-In the {ringbp} model, _isolated_ individuals have their own transmission dynamics (see `offspring_opts()` above). {ringbp} allows infected individuals in isolation to transmit (i.e. non-zero reproduction number), and can even have higher transmissibility than infectors in the community.
+In the `{ringbp}` model, _isolated_ individuals have their own transmission dynamics (see `offspring_opts()` above). `{ringbp}` allows infected individuals in isolation to transmit (i.e. non-zero reproduction number), and can even have higher transmissibility than infectors in the community.
 
 :::
 
@@ -118,7 +118,7 @@ _Contact tracing_ is the process of identifying and isolating people who have be
 
 ::: {.alert .alert-info}
 
-Quarantine in the {ringbp} model is defined as the isolation of individuals independent of their infection status. Contacts can be isolated before they are symptomatic once the infecting individual is confirmed to be infected and goes into isolation. It differs from isolation in the model, which requires the infectee to be symptomatic.
+Quarantine in the `{ringbp}` model is defined as the isolation of individuals independent of their infection status. Contacts can be isolated before they are symptomatic once the infecting individual is confirmed to be infected and goes into isolation. It differs from isolation in the model, which requires the infectee to be symptomatic.
 
 :::
 
@@ -147,11 +147,11 @@ With all components defined, simulations can be run using `scenario_sim()`. The 
 
 ::: {.alert .alert-info}
 
-_Stochastic epidemic model_: the {ringbp} model uses random simulations to reflect the inherent uncertainty in real‑world outbreaks.
+_Stochastic epidemic model_: the `{ringbp}` model uses random simulations to reflect the inherent uncertainty in real‑world outbreaks.
 
 :::
 
-We set the seed to ensure we have the same output each time the vignette is rendered. When using {ringbp}, setting the seed is not required unless you need to simulate the same outbreak multiple times.
+We set the seed to ensure we have the same output each time the vignette is rendered. When using `{ringbp}`, setting the seed is not required unless you need to simulate the same outbreak multiple times.
 
 ```{r}
 set.seed(1)
@@ -224,7 +224,7 @@ By default, extinction is defined as all infectious individuals have had the opp
 
 ## Simplified COVID-19 contact tracing effectiveness analysis
 
-Next we demonstrate how to use {ringbp} to reproduce a simplified version of the outbreak control analysis from @Hellewell2020. This study, published in the first months of the COVID-19 pandemic, modelled the probability that an introduced COVID-19 outbreak is contained by isolation and contact tracing. Containment was defined as no disease transmission between weeks 12-16 of the outbreak and the outbreak not reaching 5,000 total cases.
+Next we demonstrate how to use `{ringbp}` to reproduce a simplified version of the outbreak control analysis from @Hellewell2020. This study, published in the first months of the COVID-19 pandemic, modelled the probability that an introduced COVID-19 outbreak is contained by isolation and contact tracing. Containment was defined as no disease transmission between weeks 12-16 of the outbreak and the outbreak not reaching 5,000 total cases.
 
 Using the functions described above we define several parameter sets to analyse how varying the basic reproduction number in the community, the proportion of contacts successfully traced, and the number of initial infectors that seed independent outbreaks influence the likelihood of outbreak control. 
 
@@ -274,7 +274,7 @@ scenarios[, sims := lapply(data, \(x, n) {
 )]
 ```
 
-For a more detailed example of running {ringbp} across multiple parameter sets see the [`parameter-sweep.Rmd` vignette](parameter-sweep.html), which also includes information on how to parallelise the simulation.
+For a more detailed example of running `{ringbp}` across multiple parameter sets see the [`parameter-sweep.Rmd` vignette](parameter-sweep.html), which also includes information on how to parallelise the simulation.
 
 ```{r}
 
@@ -287,15 +287,15 @@ scenarios[,
 scenarios$pext
 ```
 
-@Hellewell2020 used {ringbp} to show that:
+@Hellewell2020 used `{ringbp}` to show that:
 
 * Outbreaks are controllable if contact tracing is fast and covers a high proportion of contacts
 * Delays in isolating cases or many undetected asymptomatic cases make control unlikely
 * Small initial clusters are easier to contain than larger ones
 
-## {ringbp} Use Cases
+## `{ringbp}` Use Cases
 
-This vignette has focused on the high-level workflow for running simulations with {ringbp}. Further uses of the package include, but are not limited to:
+This vignette has focused on the high-level workflow for running simulations with `{ringbp}`. Further uses of the package include, but are not limited to:
 
 * Simulate outbreaks under different assumptions about $R_0$, incubation period, and proportion of asymptomatic infections.
 * Explore the impact of delays in isolation and the effectiveness of contact tracing.


### PR DESCRIPTION
This PR addresses #202 by standardising the style of R packages across all documentation, using the `{pkg}` style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guide and README with consistent package name formatting.
  * Enhanced vignette documentation with improved explanations of stochastic simulation, model concepts, and multi-parameter analysis workflows.
  * Standardised inline code formatting across release notes and documentation files for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/epiforecasts/ringbp/pull/222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->