### PR TITLE
Increment to development version (v1.0.0.9000)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: ringbp
 Title: Simulate and Evaluate Targeted Interventions in Infectious Disease
     Outbreaks
-Version: 1.0.0
+Version: 1.0.0.9000
 Authors@R: c(
     person("Joel", "Hellewell", , "Joel.Hellewell@lshtm.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0003-2683-0849")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ringbp (development version)
+
 # ringbp 1.0.0
 
 * Index cases in `outbreak_setup()` are now only isolated if they test positive (using the `test_sensitivity` parameter), as opposed to previously where all symptomatic index cases were isolated. The updated `outbreak_setup()` matches the testing pathway in `outbreak_step()`. `outbreak_setup()` gains an `interventions` argument. Addresses #231 by @joshwlambert in #232 and reviewed by @pearsonca.

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,6 +22,7 @@ set.seed(111)
 [![Codecov test coverage](https://codecov.io/gh/{{ gh_repo }}/branch/main/graph/badge.svg)](https://app.codecov.io/gh/{{ gh_repo }}?branch=main)
 ![GitHub contributors](https://img.shields.io/github/contributors/{{ gh_repo }})
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3749529.svg)](https://doi.org/10.5281/zenodo.3749529)
 <!-- badges: end -->
 
 `{ringbp}` is an R package that provides methods to simulate infectious

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,9 @@ url: https://epiforecasts.io/ringbp/
 template:
   bootstrap: 5
 
+development:
+  mode: auto
+
 reference:
   - title: Model
   - subtitle: Run outbreak scenario (multiple outbreak simulations) under one set of parameters


### PR DESCRIPTION
This PR increments the package version to a development version (v1.0.0.9000), updated in the `DESCRIPTION` and `NEWS.md`. 

The pkgdown package website [`development: mode`](https://pkgdown.r-lib.org/articles/how-to-update-released-site.html?q=auto#automatic-development-mode) is set to `auto` so there will now be two versions of the package site, the release version and the dev version. 

The Zenodo DOI badge is added to the `README`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Zenodo DOI badge to README for improved citation referencing.
  * Established dedicated section in NEWS for tracking development version updates.

* **Chores**
  * Updated package version metadata for development releases.
  * Enhanced build configuration for development mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->